### PR TITLE
Add mobile-friendly metadata to themes html

### DIFF
--- a/themes/bitbucket.html
+++ b/themes/bitbucket.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body { font-family: Arial,sans-serif; color: #333; margin: 20px; font-size: 14px; line-height: 1.42857142857143; }
         img { max-width: 100%; height: auto; }

--- a/themes/dark.html
+++ b/themes/dark.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body { background-color: #202020; color: #E4E4E4; margin: 20px; font-size: 16px; line-height: 1.6; font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
         img { max-width: 100%; height: auto; }

--- a/themes/github.html
+++ b/themes/github.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body { color: #333; margin: 20px; font-size: 16px; line-height: 1.6; font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
         img { max-width: 100%; height: auto; }

--- a/themes/solarized.html
+++ b/themes/solarized.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body { background-color: #002B36; color: #DED8C5; margin: 20px; font-size: 16px; line-height: 1.6; font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
         img { max-width: 100%; height: auto; }

--- a/themes/whiteonblack.html
+++ b/themes/whiteonblack.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <style>
         body { background-color: #000000; color: #E4E4E4; margin: 20px; font-size: 16px; line-height: 1.6; font-family: "Helvetica Neue", Helvetica, "Segoe UI", Arial, freesans, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; }
         img { max-width: 100%; height: auto; }


### PR DESCRIPTION
Thanks for the nice tool. I have added mobile-friendly metadata to the html themes so that the produced html renders well on mobile. It seems a reasonable assumption to me that html produced from markdown should display well on mobile, so a header indicating that this is the case makes sense, i think.